### PR TITLE
Added prism-jsx script to enable jsx highlighting

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -123,6 +123,8 @@
         src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-markup.min.js"></script>
     <script type="text/javascript"
         src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-unescaped-markup.min.js"></script>
+    <script type="text/javascript"
+        src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-jsx.min.js"></script>
 
     {{!-- The #block helper will pull in data from the #contentFor other template files. In this case, there's some JavaScript which we only want to use in post.hbs, but it needs to be included down here, after jQuery has already loaded. --}}
     {{{block "scripts"}}}


### PR DESCRIPTION
Noticed that JSX highlighting wasn't enabled while updating this article: https://www.freecodecamp.org/news/the-react-handbook-b71c27b0a795/