### PR TITLE
feat: Enable social row and conditional comments on pages

### DIFF
--- a/page.hbs
+++ b/page.hbs
@@ -35,8 +35,15 @@ into the {body} of the default.hbs template --}}
                 </div>
             </section>
 
-        </article>
+            {{^has tag="#Disable Comments"}}
+                {{> "social-row"}}
+                {{> "comments"}}
+                <div id='discourse-comments'>
+                    <button id='trigger-load-comments'>Show comments</button>
+                </div>
+            {{/has}}
 
+        </article>
     </div>
 </main>
 

--- a/page.hbs
+++ b/page.hbs
@@ -35,13 +35,8 @@ into the {body} of the default.hbs template --}}
                 </div>
             </section>
 
-            {{^has tag="#Disable Comments"}}
-                {{> "social-row"}}
-                {{> "comments"}}
-                <div id='discourse-comments'>
-                    <button id='trigger-load-comments'>Show comments</button>
-                </div>
-            {{/has}}
+            {{> "social-row"}}
+            {{> "comments"}}
 
         </article>
     </div>

--- a/partials/comments.hbs
+++ b/partials/comments.hbs
@@ -1,0 +1,32 @@
+<script>
+  function loadDiscourseComments() {
+  var xhr = new XMLHttpRequest();
+  var file = "https://www.freecodecamp.org/forum/srv/status";
+  var randomNum = Math.round(Math.random() * 10000);
+  xhr.open('HEAD', file + "?rand=" + randomNum, true);
+  xhr.send();
+  xhr.addEventListener("readystatechange", processRequest, false);
+  function processRequest(e) {
+      if (xhr.readyState == 4) {
+          if (xhr.status >= 200 && xhr.status < 304) {
+              document.getElementById('discourse-comments').innerHTML = '';
+              DiscourseEmbed = {
+                  discourseUrl: 'https://www.freecodecamp.org/forum/',
+                  discourseEmbedUrl: '{{url absolute="true"}}'
+              };
+              var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+              d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+          } else {
+              document.getElementById('discourse-comments').innerHTML = '<div style="text-align: center;">Sorry, we could not load the comments. Please try again after some time.</div>';
+          }
+      }
+    }
+  }
+
+  if (window && window.addEventListener) {
+    window.addEventListener('load', function () {
+        document.getElementById('trigger-load-comments').onclick = loadDiscourseComments;
+    });
+  }
+</script>

--- a/partials/comments.hbs
+++ b/partials/comments.hbs
@@ -1,32 +1,38 @@
-<script>
-  function loadDiscourseComments() {
-  var xhr = new XMLHttpRequest();
-  var file = "https://www.freecodecamp.org/forum/srv/status";
-  var randomNum = Math.round(Math.random() * 10000);
-  xhr.open('HEAD', file + "?rand=" + randomNum, true);
-  xhr.send();
-  xhr.addEventListener("readystatechange", processRequest, false);
-  function processRequest(e) {
-      if (xhr.readyState == 4) {
-          if (xhr.status >= 200 && xhr.status < 304) {
-              document.getElementById('discourse-comments').innerHTML = '';
-              DiscourseEmbed = {
-                  discourseUrl: 'https://www.freecodecamp.org/forum/',
-                  discourseEmbedUrl: '{{url absolute="true"}}'
-              };
-              var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
-              d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
-              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
-          } else {
-              document.getElementById('discourse-comments').innerHTML = '<div style="text-align: center;">Sorry, we could not load the comments. Please try again after some time.</div>';
-          }
+{{^has tag="#disable-comments"}}
+  <script>
+    function loadDiscourseComments() {
+    var xhr = new XMLHttpRequest();
+    var file = "https://www.freecodecamp.org/forum/srv/status";
+    var randomNum = Math.round(Math.random() * 10000);
+    xhr.open('HEAD', file + "?rand=" + randomNum, true);
+    xhr.send();
+    xhr.addEventListener("readystatechange", processRequest, false);
+    function processRequest(e) {
+        if (xhr.readyState == 4) {
+            if (xhr.status >= 200 && xhr.status < 304) {
+                document.getElementById('discourse-comments').innerHTML = '';
+                DiscourseEmbed = {
+                    discourseUrl: 'https://www.freecodecamp.org/forum/',
+                    discourseEmbedUrl: '{{url absolute="true"}}'
+                };
+                var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+                d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+            } else {
+                document.getElementById('discourse-comments').innerHTML = '<div style="text-align: center;">Sorry, we could not load the comments. Please try again after some time.</div>';
+            }
+        }
       }
     }
-  }
 
-  if (window && window.addEventListener) {
-    window.addEventListener('load', function () {
-        document.getElementById('trigger-load-comments').onclick = loadDiscourseComments;
-    });
-  }
-</script>
+    if (window && window.addEventListener) {
+      window.addEventListener('load', function () {
+          document.getElementById('trigger-load-comments').onclick = loadDiscourseComments;
+      });
+    }
+  </script>
+
+  <div id='discourse-comments'>
+    <button id='trigger-load-comments'>Show comments</button>
+  </div>
+{{/has}}

--- a/post.hbs
+++ b/post.hbs
@@ -80,43 +80,7 @@ into the {body} of the default.hbs template --}}
             {{/if}}
 
             {{> "social-row"}}
-            {{!--
-            <section class="post-full-comments">
-                If you want to embed comments, this is a good place to do it!
-            </section> --}}
-
-            <script type="text/javascript">
-                function loadDiscourseComments() {
-                    var xhr = new XMLHttpRequest();
-                    var file = "https://www.freecodecamp.org/forum/srv/status";
-                    var randomNum = Math.round(Math.random() * 10000);
-                    xhr.open('HEAD', file + "?rand=" + randomNum, true);
-                    xhr.send();
-                    xhr.addEventListener("readystatechange", processRequest, false);
-                    function processRequest(e) {
-                        if (xhr.readyState == 4) {
-                            if (xhr.status >= 200 && xhr.status < 304) {
-                                document.getElementById('discourse-comments').innerHTML = '';
-                                DiscourseEmbed = {
-                                    discourseUrl: 'https://www.freecodecamp.org/forum/',
-                                    discourseEmbedUrl: '{{url absolute="true"}}'
-                                };
-                                var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
-                                d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
-                                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
-                            } else {
-                                document.getElementById('discourse-comments').innerHTML = '<div style="text-align: center;">Sorry, we could not load the comments. Please try again after sometime.</div>';
-                            }
-                        }
-                    }
-                }
-                if (window && window.addEventListener) {
-                    window.addEventListener('load', function () {
-                        document.getElementById('trigger-load-comments').onclick = loadDiscourseComments;
-                    });
-                }
-            </script>
-
+            {{> "comments"}}
             <div id='discourse-comments'>
                 <button id='trigger-load-comments'>Show comments</button>
             </div>

--- a/post.hbs
+++ b/post.hbs
@@ -81,9 +81,6 @@ into the {body} of the default.hbs template --}}
 
             {{> "social-row"}}
             {{> "comments"}}
-            <div id='discourse-comments'>
-                <button id='trigger-load-comments'>Show comments</button>
-            </div>
 
         </article>
     </div>


### PR DESCRIPTION
Re-enable comments on pages without the #disable-comments internal tag, this time using a partial to load the script.