### PR TITLE
fix: Twitter and Facebook share links

### DIFF
--- a/partials/social-row.hbs
+++ b/partials/social-row.hbs
@@ -2,17 +2,14 @@
 
 <div class="social-row">
     <button class="twitter"
-        onclick="window.open('https://twitter.com/share?text={{encode title}}{{#primary_author}}{{#if twitter}}%20by%20{{twitter}}{{/if}}{{/primary_author}}&amp;url={{url absolute="true"}}', 'share-twitter', 'width=550,height=235');return false;">
+        onclick="window.open(`https://twitter.com/share?text={{encode title}}{{#primary_author}}{{#if twitter}}%20by%20{{twitter}}{{/if}}{{/primary_author}}&amp;url={{url absolute="true"}}`, 'share-twitter', 'width=550,height=235');return false;">
         {{> "icons/twitter"}} <span>&nbsp;Tweet this to your followers</span></button>
     <div></div>
     <button class="email"
-        onclick="window.location.href = 'mailto:?subject=helpful freeCodeCamp article: {{title}}  &amp;body={{title}} {{url absolute="true"}}';">
+        onclick="window.location.href = `mailto:?subject=helpful freeCodeCamp article: {{title}}  &amp;body={{title}} {{url absolute="true"}}`;">
         {{> "icons/email"}} <span>Email this to a friend</span></button>
-
-    {{#primary_author}}
     <div></div>
     <button class="facebook"
-        onclick="window.open('https://www.facebook.com/sharer/sharer.php?u={{url absolute="true"}}', 'share-facebook','width=580,height=296');return false;">
+        onclick="window.open(`https://www.facebook.com/sharer/sharer.php?u={{url absolute="true"}}`, 'share-facebook','width=580,height=296');return false;">
         {{> "icons/facebook"}} <span>Share this with your friends</span></button>
-    {{/primary_author}}
 </div>


### PR DESCRIPTION
Fixed problem with single quote marks in the titles when sharing links, and sharing the story rather than the author on Facebook.

Here are some articles to test this with:
* https://www.freecodecamp.dev/news/learn-to-develop-neural-networks-using-tensorflow-2-0-in-this-beginners-course/
* https://www.freecodecamp.dev/news/escape-tests-test/

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/36858
Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/36859