### PR TITLE
docs: update usage instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,10 +45,10 @@ cd content/theme/
 git clone https://github.com/freeCodeCamp/news-theme.git
 ```
 
-The theme styles are compiled using Gulp/PostCSS to polyfill future CSS spec. You'll need [Node](https://nodejs.org/), and [Gulp](https://gulpjs.com) installed globally. After that, from the theme's root directory:
+The theme styles are compiled using Gulp/PostCSS to polyfill future CSS spec. You'll need [Node](https://nodejs.org/). After that, from the theme's root directory:
 
 ```bash
-npm run install
+npm install
 npm run develop
 ```
 


### PR DESCRIPTION
## Issue
`npm run install` isn't valid, it's simply `npm install`. `npm run install` would be valid if it were a script set up with the package, however that's not the case.

Gulp is not required to be installed globally to be used. When it's added as a dependency and further used within a script, npm is able to resolve the dependency in `node_modules` for use.

## Solution
* `npm run install` => `npm install`
* Removed installing Gulp globally as a requirement