### PR TITLE
fix: repositioning of news search box magnifying glass

### DIFF
--- a/assets/css/algolia-search.css
+++ b/assets/css/algolia-search.css
@@ -205,7 +205,8 @@ a:active {
         left: 15px;
     }
     .ais-SearchBox-submit {
-        left: 3rem;
+        /* 30px = 10px of nav padding + 15px of form padding + 5px of additional padding */
+        left: 30px;
         top: 20%;
     }
 }


### PR DESCRIPTION
This is a fix of issue [#37778](https://github.com/freeCodeCamp/freeCodeCamp/issues/37778): 'news search box magnifying glass needs repositioning'

At present: when browser's font size is changed the magnifying glass is being repositioned.

To avoid this repositioning  I've changed the left position of the button, from 3rem to 30px. 30px is calculated on the basis of parents' paddings which are px values (described in comment).

I've tested the fix in Chrome and Mozilla but not on the local build but by changing the css value in devtools.


