### PR TITLE
Removed max-height to fix issue #37901

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -121,7 +121,6 @@ body {
     align-items: center;
     padding: 80px 10px 30px 10px;
     min-height: 200px;
-    max-height: 450px;
     text-align: center;
     color: white;
 }


### PR DESCRIPTION
The under-header-content has a max-height of 450px that makes the tags overflow and not responsive in mobile view
## Before:

![](https://user-images.githubusercontent.com/34748637/70460558-ea919180-1ab6-11ea-9152-bbf44cb98e48.png)

## After:

![fcc](https://user-images.githubusercontent.com/34748637/70828220-41ff6c80-1deb-11ea-8b49-9fb44ba05456.png)

## Desktop View After:
![fcc-2](https://user-images.githubusercontent.com/34748637/70828363-8559db00-1deb-11ea-8a41-20d440801778.png)
