### PR TITLE
Fix: Update size attribute for post-card-image to match actual image size in template

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -8,7 +8,8 @@
         <img class="post-card-image" srcset="{{img_url feature_image size="s"}} 300w,
                     {{img_url feature_image size="m"}} 600w,
                     {{img_url feature_image size="l"}} 1000w,
-                    {{img_url feature_image size="xl"}} 2000w" sizes="(max-width: 1000px) 400px, 700px"
+                    {{img_url feature_image size="xl"}} 2000w"
+            sizes="(min-width: 768px) 285px, 100vw"
             onerror="this.style.display='none'" src="{{img_url feature_image size="m"}}" alt="{{title}}" />
     </a>
     {{else}}


### PR DESCRIPTION
**Problem:**
Images on news page has `sizes` attribute set in a way that it always serve image that is 1000px wide for every device resolution.

**How it was solved:**
`size` attibute is set according to how the image is actually displayed on page. Now it takes into account that for device resolution > 768px the image is only 285px wide.