### PR TITLE
Fix: Post headlines are covered by navigation bar when "jump to" link is used

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -836,6 +836,11 @@ make sure this only happens on large viewports / desktop-ish devices.
   min-width: 100%;
 }
 
+.post-full-content h2:target,
+.post-full-content h3:target {
+  scroll-margin-top: calc(var(--header-height) + .5em);
+}
+
 .post-full-content li {
   word-break: break-word;
 }


### PR DESCRIPTION
Fixes freeCodeCamp/freeCodeCamp#38870

**Problem:**

See https://github.com/freeCodeCamp/freeCodeCamp/issues/38870#issue-622930251

**Proposed solution:**

Use [`scroll-margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top) CSS property which was designed just for cases like this. Also it is widely supported by browsers.

**Possible issues:**

`scroll-margin-top` is not supported by IE11
